### PR TITLE
Proposed variables.js defaults

### DIFF
--- a/packages/eslint-config-airbnb-base/rules/variables.js
+++ b/packages/eslint-config-airbnb-base/rules/variables.js
@@ -44,8 +44,7 @@ module.exports = {
 
     // disallow use of undefined variable
     // https://eslint.org/docs/rules/no-undefined
-    // TODO: enable?
-    'no-undefined': 'off',
+    'no-undefined': 'error',
 
     // disallow declaration of variables that are not used in the code
     'no-unused-vars': ['error', { vars: 'all', args: 'after-used', ignoreRestSiblings: true }],


### PR DESCRIPTION
No significant changes proposed, other than enabling `'no-undefined'` which prevents naming a local variable undefined (e.g. `const undefined = 'something';`).